### PR TITLE
Moved changeTableNameForSP to utils and updated references

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudspannerecosystem/dynamodb-adapter/models"
 	"github.com/cloudspannerecosystem/dynamodb-adapter/pkg/errors"
 	"github.com/cloudspannerecosystem/dynamodb-adapter/pkg/logger"
+	"github.com/cloudspannerecosystem/dynamodb-adapter/utils"
 )
 
 // Configuration struct
@@ -87,7 +88,7 @@ func InitConfig(box *rice.Box) {
 			logger.LogFatal(err)
 		}
 		for k, v := range tmp {
-			models.SpannerTableMap[changeTableNameForSpanner(k)] = v
+			models.SpannerTableMap[utils.ChangeTableNameForSpanner(k)] = v
 		}
 	})
 }
@@ -108,11 +109,4 @@ func GetTableConf(tableName string) (models.TableConfig, error) {
 		return tableConf, nil
 	}
 	return models.TableConfig{}, errors.New("ResourceNotFoundException", tableName)
-}
-
-// changeTableNameForSpanner - ReplaceAll the hyphens (-) with underscore for given table name
-// https://cloud.google.com/spanner/docs/data-definition-language#naming_conventions
-func changeTableNameForSpanner(tableName string) string {
-	tableName = strings.ReplaceAll(tableName, "-", "_")
-	return tableName
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -90,37 +90,3 @@ func TestGetTableConf(t *testing.T) {
 		assert.Equal(t, got, tc.want)
 	}
 }
-
-func TestChangeTableNameForSP(t *testing.T) {
-	tests := []struct {
-		testName  string
-		tableName string
-		want      string
-	}{
-		{
-			"empty table Name",
-			"",
-			"",
-		},
-		{
-			"table name without underscore",
-			"department",
-			"department",
-		},
-		{
-			"table name with one underscore",
-			"department-data",
-			"department_data",
-		},
-		{
-			"table name with more than one underscore",
-			"department-data-1-7",
-			"department_data_1_7",
-		},
-	}
-
-	for _, tc := range tests {
-		got := changeTableNameForSP(tc.tableName)
-		assert.Equal(t, got, tc.want)
-	}
-}

--- a/integrationtest/setup.go
+++ b/integrationtest/setup.go
@@ -250,11 +250,6 @@ func getColNameAndType(stmt string) (string, string) {
 	return tokens[0], tokens[1]
 }
 
-func changeTableNameForSP(tableName string) string {
-	tableName = strings.ReplaceAll(tableName, "-", "_")
-	return tableName
-}
-
 // spannerBatchPut - this insert or update data in batch
 func spannerBatchPut(ctx context.Context, db string, m []*spanner.Mutation) error {
 	client, err := spanner.NewClient(ctx, db)

--- a/service/services/services.go
+++ b/service/services/services.go
@@ -49,7 +49,7 @@ func getSpannerProjections(projectionExpression, table string, expressionAttribu
 		}
 	}
 
-	linq.From(projectionCols).IntersectByT(linq.From(models.TableColumnMap[changeTableNameForSP(table)]), func(str string) string {
+	linq.From(projectionCols).IntersectByT(linq.From(models.TableColumnMap[utils.ChangeTableNameForSpanner(table)]), func(str string) string {
 		return str
 	}).ToSlice(&projectionCols)
 	return projectionCols
@@ -328,7 +328,7 @@ func parseSpannerColumns(query *models.Query, tPkey, pKey, sKey string) ([]strin
 	if query.OnlyCount {
 		return []string{"count"}, "COUNT(" + pKey + ") AS count", true, nil
 	}
-	table := changeTableNameForSP(query.TableName)
+	table := utils.ChangeTableNameForSpanner(query.TableName)
 	var cols []string
 	if query.ProjectionExpression != "" {
 		cols = getSpannerProjections(query.ProjectionExpression, query.TableName, query.ExpressionAttributeNames)
@@ -380,13 +380,8 @@ func parseSpannerColumns(query *models.Query, tPkey, pKey, sKey string) ([]strin
 	return cols, colStr, false, nil
 }
 
-func changeTableNameForSP(tableName string) string {
-	tableName = strings.ReplaceAll(tableName, "-", "_")
-	return tableName
-}
-
 func parseSpannerTableName(query *models.Query) string {
-	tableName := changeTableNameForSP(query.TableName)
+	tableName := utils.ChangeTableNameForSpanner(query.TableName)
 	if query.IndexName != "" {
 		tableName += "@{FORCE_INDEX=" + query.IndexName + "}"
 	}

--- a/service/services/services_test.go
+++ b/service/services/services_test.go
@@ -487,39 +487,6 @@ func Test_parseSpannerColumns(t *testing.T) {
 	}
 }
 
-func Test_changeTableNameForSP(t *testing.T) {
-	tests := []struct {
-		tableName string
-		want      string
-	}{
-		{
-			"",
-			"",
-		},
-		{
-			"anyTableName",
-			"anyTableName",
-		},
-		{
-			"table_name_with_underscores",
-			"table_name_with_underscores",
-		},
-		{
-			"table-name-with-hypen",
-			"table_name_with_hypen",
-		},
-		{
-			"table_name-with-hypen_and_underscore",
-			"table_name_with_hypen_and_underscore",
-		},
-	}
-
-	for _, tc := range tests {
-		got := changeTableNameForSP(tc.tableName)
-		assert.Equal(t, got, tc.want)
-	}
-}
-
 func Test_parseSpannerTableName(t *testing.T) {
 	tests := []struct {
 		testName   string

--- a/storage/spanner.go
+++ b/storage/spanner.go
@@ -52,16 +52,16 @@ func (s Storage) SpannerBatchGet(ctx context.Context, tableName string, pKeys, s
 	}
 	if len(projectionCols) == 0 {
 		var ok bool
-		projectionCols, ok = models.TableColumnMap[changeTableNameForSP(tableName)]
+		projectionCols, ok = models.TableColumnMap[utils.ChangeTableNameForSpanner(tableName)]
 		if !ok {
 			return nil, errors.New("ResourceNotFoundException", tableName)
 		}
 	}
-	colDLL, ok := models.TableDDL[changeTableNameForSP(tableName)]
+	colDLL, ok := models.TableDDL[utils.ChangeTableNameForSpanner(tableName)]
 	if !ok {
 		return nil, errors.New("ResourceNotFoundException", tableName)
 	}
-	tableName = changeTableNameForSP(tableName)
+	tableName = utils.ChangeTableNameForSpanner(tableName)
 	client := s.getSpannerClient(tableName)
 	itr := client.Single().Read(ctx, tableName, spanner.KeySets(keySet...), projectionCols)
 	defer itr.Stop()
@@ -290,16 +290,16 @@ func (s Storage) SpannerGet(ctx context.Context, tableName string, pKeys, sKeys 
 	}
 	if len(projectionCols) == 0 {
 		var ok bool
-		projectionCols, ok = models.TableColumnMap[changeTableNameForSP(tableName)]
+		projectionCols, ok = models.TableColumnMap[utils.ChangeTableNameForSpanner(tableName)]
 		if !ok {
 			return nil, errors.New("ResourceNotFoundException", tableName)
 		}
 	}
-	colDLL, ok := models.TableDDL[changeTableNameForSP(tableName)]
+	colDLL, ok := models.TableDDL[utils.ChangeTableNameForSpanner(tableName)]
 	if !ok {
 		return nil, errors.New("ResourceNotFoundException", tableName)
 	}
-	tableName = changeTableNameForSP(tableName)
+	tableName = utils.ChangeTableNameForSpanner(tableName)
 	client := s.getSpannerClient(tableName)
 	row, err := client.Single().ReadRow(ctx, tableName, key, projectionCols)
 	if err := errors.AssignError(err); err != nil {
@@ -311,7 +311,7 @@ func (s Storage) SpannerGet(ctx context.Context, tableName string, pKeys, sKeys 
 
 // ExecuteSpannerQuery - this will execute query on spanner database
 func (s Storage) ExecuteSpannerQuery(ctx context.Context, table string, cols []string, isCountQuery bool, stmt spanner.Statement) ([]map[string]interface{}, error) {
-	colDLL, ok := models.TableDDL[changeTableNameForSP(table)]
+	colDLL, ok := models.TableDDL[utils.ChangeTableNameForSpanner(table)]
 	if !ok {
 		return nil, errors.New("ResourceNotFoundException", table)
 	}
@@ -364,7 +364,7 @@ func (s Storage) SpannerPut(ctx context.Context, table string, m map[string]inte
 				return errors.New("ConditionalCheckFailedException", eval, expr)
 			}
 		}
-		table = changeTableNameForSP(table)
+		table = utils.ChangeTableNameForSpanner(table)
 		for k, v := range tmpMap {
 			update[k] = v
 		}
@@ -375,7 +375,7 @@ func (s Storage) SpannerPut(ctx context.Context, table string, m map[string]inte
 }
 
 func evaluateConditionalExpression(ctx context.Context, t *spanner.ReadWriteTransaction, table string, m map[string]interface{}, e *models.Eval, expr *models.UpdateExpressionCondition) (bool, error) {
-	colDDL, ok := models.TableDDL[changeTableNameForSP(table)]
+	colDDL, ok := models.TableDDL[utils.ChangeTableNameForSpanner(table)]
 	if !ok {
 		return false, errors.New("ResourceNotFoundException", table)
 	}
@@ -411,10 +411,10 @@ func evaluateConditionalExpression(ctx context.Context, t *spanner.ReadWriteTran
 		cols = e.Cols
 	}
 
-	linq.From(cols).IntersectByT(linq.From(models.TableColumnMap[changeTableNameForSP(table)]), func(str string) string {
+	linq.From(cols).IntersectByT(linq.From(models.TableColumnMap[utils.ChangeTableNameForSpanner(table)]), func(str string) string {
 		return str
 	}).ToSlice(&cols)
-	r, err := t.ReadRow(ctx, changeTableNameForSP(table), key, cols)
+	r, err := t.ReadRow(ctx, utils.ChangeTableNameForSpanner(table), key, cols)
 	if e := errors.AssignError(err); e != nil {
 		return false, e
 	}
@@ -528,8 +528,8 @@ func (s Storage) performPutOperation(ctx context.Context, t *spanner.ReadWriteTr
 // SpannerBatchPut - this insert or update data in batch
 func (s Storage) SpannerBatchPut(ctx context.Context, table string, m []map[string]interface{}) error {
 	mutations := make([]*spanner.Mutation, len(m))
-	ddl := models.TableDDL[changeTableNameForSP(table)]
-	table = changeTableNameForSP(table)
+	ddl := models.TableDDL[utils.ChangeTableNameForSpanner(table)]
+	table = utils.ChangeTableNameForSpanner(table)
 	for i := 0; i < len(m); i++ {
 		for k, v := range m[i] {
 			t, ok := ddl[k]
@@ -570,7 +570,7 @@ func (s Storage) SpannerDelete(ctx context.Context, table string, m map[string]i
 		if err != nil {
 			return err
 		}
-		table = changeTableNameForSP(table)
+		table = utils.ChangeTableNameForSpanner(table)
 
 		pKey := tableConf.PartitionKey
 		pValue, ok := tmpMap[pKey]
@@ -606,7 +606,7 @@ func (s Storage) SpannerBatchDelete(ctx context.Context, table string, keys []ma
 	if err != nil {
 		return err
 	}
-	table = changeTableNameForSP(table)
+	table = utils.ChangeTableNameForSpanner(table)
 
 	pKey := tableConf.PartitionKey
 	ms := make([]*spanner.Mutation, len(keys))
@@ -643,7 +643,7 @@ func (s Storage) SpannerAdd(ctx context.Context, table string, m map[string]inte
 	if err != nil {
 		return nil, err
 	}
-	colDLL, ok := models.TableDDL[changeTableNameForSP(table)]
+	colDLL, ok := models.TableDDL[utils.ChangeTableNameForSpanner(table)]
 	if !ok {
 		return nil, errors.New("ResourceNotFoundException", table)
 	}
@@ -687,7 +687,7 @@ func (s Storage) SpannerAdd(ctx context.Context, table string, m map[string]inte
 				return errors.New("ConditionalCheckFailedException")
 			}
 		}
-		table = changeTableNameForSP(table)
+		table = utils.ChangeTableNameForSpanner(table)
 
 		r, err := t.ReadRow(ctx, table, key, cols)
 		if err != nil {
@@ -804,7 +804,7 @@ func (s Storage) SpannerDel(ctx context.Context, table string, m map[string]inte
 	if err != nil {
 		return err
 	}
-	colDLL, ok := models.TableDDL[changeTableNameForSP(table)]
+	colDLL, ok := models.TableDDL[utils.ChangeTableNameForSpanner(table)]
 	if !ok {
 		return errors.New("ResourceNotFoundException", table)
 	}
@@ -847,7 +847,7 @@ func (s Storage) SpannerDel(ctx context.Context, table string, m map[string]inte
 				return errors.New("ConditionalCheckFailedException")
 			}
 		}
-		table = changeTableNameForSP(table)
+		table = utils.ChangeTableNameForSpanner(table)
 
 		r, err := t.ReadRow(ctx, table, key, cols)
 		if err != nil {
@@ -933,7 +933,7 @@ func (s Storage) SpannerRemove(ctx context.Context, table string, m map[string]i
 		for _, col := range colsToRemove {
 			tmpMap[col] = null
 		}
-		table = changeTableNameForSP(table)
+		table = utils.ChangeTableNameForSpanner(table)
 		mutation := spanner.InsertOrUpdateMap(table, tmpMap)
 		err := t.BufferWrite([]*spanner.Mutation{mutation})
 		if err != nil {
@@ -942,11 +942,6 @@ func (s Storage) SpannerRemove(ctx context.Context, table string, m map[string]i
 		return nil
 	})
 	return err
-}
-
-func changeTableNameForSP(tableName string) string {
-	tableName = strings.ReplaceAll(tableName, "-", "_")
-	return tableName
 }
 
 var queryHash = make(map[string]string)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloudspannerecosystem/dynamodb-adapter/config"
 	"github.com/cloudspannerecosystem/dynamodb-adapter/models"
 	"github.com/cloudspannerecosystem/dynamodb-adapter/pkg/logger"
+	"github.com/cloudspannerecosystem/dynamodb-adapter/utils"
 	"github.com/tidwall/gjson"
 )
 
@@ -108,5 +109,5 @@ func GetStorageInstance() *Storage {
 }
 
 func (s Storage) getSpannerClient(tableName string) *spanner.Client {
-	return s.spannerClient[models.SpannerTableMap[changeTableNameForSP(tableName)]]
+	return s.spannerClient[models.SpannerTableMap[utils.ChangeTableNameForSpanner(tableName)]]
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -168,3 +168,10 @@ func ParseBeginsWith(rangeExpression string) (string, string, string) {
 
 	return "", "", rangeExpression
 }
+
+// ChangeTableNameForSpanner - ReplaceAll the hyphens (-) with underscore for given table name
+// https://cloud.google.com/spanner/docs/data-definition-language#naming_conventions
+func ChangeTableNameForSpanner(tableName string) string {
+	tableName = strings.ReplaceAll(tableName, "-", "_")
+	return tableName
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -212,3 +212,37 @@ func TestParseBeginsWith(t *testing.T) {
 		assert.Equal(t, third, tc.want["third"])
 	}
 }
+
+func TestChangeTableNameForSpanner(t *testing.T) {
+	tests := []struct {
+		testName  string
+		tableName string
+		want      string
+	}{
+		{
+			"empty table Name",
+			"",
+			"",
+		},
+		{
+			"table name without underscore",
+			"department",
+			"department",
+		},
+		{
+			"table name with one underscore",
+			"department-data",
+			"department_data",
+		},
+		{
+			"table name with more than one underscore",
+			"department-data-1-7",
+			"department_data_1_7",
+		},
+	}
+
+	for _, tc := range tests {
+		got := ChangeTableNameForSpanner(tc.tableName)
+		assert.Equal(t, got, tc.want)
+	}
+}


### PR DESCRIPTION
Fixes #38 

Moved changeTableNameForSP to the utils package and renamed to ChangeTableNameForSpanner to make it more clear.  Also updated references to the new function and removed duplicate code.