### PR TITLE
Adding models for the BatchWriteItem response and error handling.

### DIFF
--- a/models/model.go
+++ b/models/model.go
@@ -170,6 +170,11 @@ type BatchWriteItem struct {
 	RequestItems map[string][]BatchWriteSubItems `json:"RequestItems"`
 }
 
+//BatchWriteItemResponse for Batch Operation
+type BatchWriteItemResponse struct {
+	UnprocessedItems map[string][]BatchWriteSubItems `json:"UnprocessedItems"`
+}
+
 //BatchWriteSubItems is for BatchWriteItem
 type BatchWriteSubItems struct {
 	DelReq BatchDeleteItem `json:"DeleteRequest"`


### PR DESCRIPTION
Fixes #46

This PR add models for BatchWriteItemResponse, so that we return a properly formatted response to the Dynamo SDK.  It also changes how BatchWriteItem handles errors, so that we return unprocessed items if there are any.  

Each table that is included in the BatchWriteItem is split into two sets of mutations, one for deletes and one for puts. All puts and deletes for each table are applied at the same time in Spanner using the [mutation modification API](https://cloud.google.com/spanner/docs/modify-mutation-api), so they all happen in one atomic transaction. Which means all deletes or puts for a table with either succeed or fail all together.  If that happens those items are collected and returned back in the response as unprocessed items.

Note: This implementation is a slight variation from how Dynamo works, because they all fail or succeed together, whereas, Dynamo would let a subset succeed and the remaining failed ones would only be returned as unprocessed.  While this could be supported in the adapter, the current implementation seems like a decent compromise to maximize the benefit of Spanner while staying close to Dynamo.

- [x] Tests pass