### PR TITLE
Updating the Dockerfile to use golang 1.22 as the base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.22
 
 
 # Set the Current Working Directory inside the container


### PR DESCRIPTION
Updates the base image in the Dockerfile to use golang 1.22, this makes the build much happier.